### PR TITLE
feat: add better auto update infrastructure

### DIFF
--- a/src/infra/autoupdate/app-dev-update.yml
+++ b/src/infra/autoupdate/app-dev-update.yml
@@ -1,0 +1,3 @@
+owner: idane
+repo: boost_tmp
+provider: github

--- a/src/infra/autoupdate/appUpdater.ts
+++ b/src/infra/autoupdate/appUpdater.ts
@@ -1,0 +1,104 @@
+import { autoUpdater, UpdateInfo } from 'electron-updater';
+import path from 'path';
+import log from 'electron-log';
+import { BrowserWindow } from 'electron';
+import { systemEvents } from '../events';
+import { configurationStore } from '../store/store';
+
+export class AppUpdater {
+  constructor(autoUpdate = false) {
+    if (process.env.NODE_ENV === 'development') {
+      autoUpdater.updateConfigPath = path.join(__dirname, 'app-dev-update.yml');
+    }
+    this.updateAutoUpdate(autoUpdate);
+    log.transports.file.level = 'info';
+
+    autoUpdater.logger = log;
+    autoUpdater.on('checking-for-update', () => {
+      log.silly('Checking for update...');
+      systemEvents.emit('checking-for-update');
+    });
+    autoUpdater.on('update-available', (info) => {
+      log.silly(`Update available: ${JSON.stringify(info)}`);
+      systemEvents.emit('update-available', info);
+    });
+
+    autoUpdater.on('update-not-available', (info) => {
+      log.silly(`Update not available. ${JSON.stringify(info)}`);
+      systemEvents.emit('update-not-available', info);
+    });
+
+    autoUpdater.on('error', (err) => {
+      log.error(`Error in auto-updater. ${err}`);
+      systemEvents.emit('update-error', err);
+    });
+
+    autoUpdater.on('download-progress', (info) => {
+      log.silly(`Download progress: ${JSON.stringify(info)}`);
+      systemEvents.emit('update-download-progress', info);
+    });
+
+    autoUpdater.on('update-downloaded', (info) => {
+      log.silly(`Update downloaded: ${JSON.stringify(info)}`);
+      systemEvents.emit('update-downloaded', info);
+    });
+
+    autoUpdater.on('update-cancelled', (info) => {
+      log.silly(`Update cancelled: ${JSON.stringify(info)}`);
+      systemEvents.emit('update-cancelled', info);
+    });
+  }
+
+  updateAutoUpdate(autoUpdate: boolean) {
+    autoUpdater.autoDownload = autoUpdate;
+    autoUpdater.autoInstallOnAppQuit = autoUpdate;
+    log.info(`autoUpdate update set to ${autoUpdate} `);
+  }
+
+  async checkForUpdates(): Promise<UpdateInfo | undefined> {
+    const result = await autoUpdater.checkForUpdates();
+    return result?.updateInfo;
+  }
+
+  downloadUpdate() {
+    autoUpdater.downloadUpdate();
+  }
+
+  quitAndInstall() {
+    autoUpdater.quitAndInstall();
+  }
+}
+
+export function initializeAppUpdaterSubscriptions(window: BrowserWindow) {
+  systemEvents.on('checking-for-update', () => {
+    window.webContents.send('app:checkingForUpdate');
+  });
+
+  systemEvents.on('update-available', (info) => {
+    window.webContents.send('app:updateAvailable', info);
+  });
+
+  systemEvents.on('update-not-available', (info) => {
+    window.webContents.send('app:updateNotAvailable', info);
+  });
+
+  systemEvents.on('update-download-progress', (info) => {
+    window.webContents.send('app:updateDownloadProgress', info);
+  });
+
+  systemEvents.on('update-downloaded', (info) => {
+    window.webContents.send('app:updateDownloaded', info);
+  });
+
+  systemEvents.on('update-error', (error) => {
+    window.webContents.send('app:updateError', error);
+  });
+}
+
+configurationStore.onDidChange('autoUpdateEnabled', (newValue) => {
+  if (newValue !== undefined) {
+    appUpdater.updateAutoUpdate(newValue);
+  }
+});
+
+export const appUpdater = new AppUpdater(configurationStore.get('autoUpdateEnabled'));

--- a/src/infra/autoupdate/index.ts
+++ b/src/infra/autoupdate/index.ts
@@ -1,0 +1,1 @@
+import './main';

--- a/src/infra/autoupdate/main.ts
+++ b/src/infra/autoupdate/main.ts
@@ -1,0 +1,6 @@
+import { ipcMain } from 'electron';
+import { appUpdater } from './appUpdater';
+
+ipcMain.handle('appUpdater:checkForUpdates', () => appUpdater.checkForUpdates());
+ipcMain.on('appUpdater:downloadUpdate', () => appUpdater.downloadUpdate());
+ipcMain.on('appUpdater:quitAndInstall', () => appUpdater.quitAndInstall());

--- a/src/infra/autoupdate/renderer.ts
+++ b/src/infra/autoupdate/renderer.ts
@@ -1,0 +1,7 @@
+import { ipcRenderer } from 'electron';
+
+export const appUpdaterBridge: AppUpdaterBridge = {
+  checkForUpdates: () => ipcRenderer.invoke('appUpdater:checkForUpdates'),
+  downloadUpdate: () => ipcRenderer.send('appUpdater:downloadUpdate'),
+  quitAndInstall: () => ipcRenderer.send('appUpdater:quitAndInstall'),
+};

--- a/src/infra/autoupdate/types.d.ts
+++ b/src/infra/autoupdate/types.d.ts
@@ -1,0 +1,15 @@
+import { UpdateInfo } from 'electron-updater';
+
+declare global {
+  type AppUpdaterBridge = {
+    checkForUpdates(): Promise<UpdateInfo>;
+    downloadUpdate(): void;
+    quitAndInstall(): void;
+  };
+
+  interface Window {
+    appUpdater: AppUpdaterBridge;
+  }
+}
+
+export {};

--- a/src/infra/events/events.ts
+++ b/src/infra/events/events.ts
@@ -1,3 +1,6 @@
+import { UpdateInfo } from 'electron-updater';
+import { ProgressInfo } from 'electron-builder';
+
 export type Events = {
   /**
    * System
@@ -5,4 +8,22 @@ export type Events = {
   'daemon-ready': () => void;
   'daemon-healthy': () => void;
   'daemon-unhealthy': () => void;
+
+  /**
+   * Updates
+   */
+
+  'checking-for-update': () => void;
+
+  'update-available': (info: UpdateInfo) => void;
+
+  'update-not-available': (info: UpdateInfo) => void;
+
+  'update-download-progress': (info: ProgressInfo) => void;
+
+  'update-downloaded': (info: UpdateInfo) => void;
+
+  'update-error': (error: Error) => void;
+
+  'update-cancelled': (info: UpdateInfo) => void;
 };

--- a/src/infra/index.ts
+++ b/src/infra/index.ts
@@ -1,4 +1,5 @@
 import './store';
+import './autoupdate';
 import './daemon';
 import './rendererUtils';
 import './ui';

--- a/src/infra/store/renderer.ts
+++ b/src/infra/store/renderer.ts
@@ -26,4 +26,10 @@ export const configurationStoreBridge: ConfigurationBridge<keyof Configuration> 
   setElectronErrorReportingEnabled(enabled: boolean): void {
     ipcRenderer.send('configurationStore:set', 'errorReportingEnabled', enabled);
   },
+  isAutoUpdateEnabled(): boolean {
+    return ipcRenderer.sendSync('configurationStore:get', 'autoUpdateEnabled');
+  },
+  setAutoUpdateEnabled(enabled: boolean): void {
+    ipcRenderer.send('configurationStore:set', 'autoUpdateEnabled', enabled);
+  },
 };

--- a/src/infra/store/store.ts
+++ b/src/infra/store/store.ts
@@ -5,6 +5,10 @@ export const defaults = {
    * Whether Sentry error reporting is enabled or not.
    */
   errorReportingEnabled: true,
+  /**
+   * Whether auto-updates are enabled or not.
+   */
+  autoUpdateEnabled: true,
 };
 
 export type Configuration = typeof defaults;

--- a/src/infra/store/types.d.ts
+++ b/src/infra/store/types.d.ts
@@ -10,6 +10,10 @@ declare global {
     clear(): void;
     isErrorReportingEnabled(): boolean;
     setElectronErrorReportingEnabled(enabled: boolean): void;
+
+    isAutoUpdateEnabled(): boolean;
+
+    setAutoUpdateEnabled(enabled: boolean): void;
   };
 
   interface Window {

--- a/src/infra/subscriptions/subscriptions.ts
+++ b/src/infra/subscriptions/subscriptions.ts
@@ -1,9 +1,22 @@
 import { IpcRendererEvent } from 'electron';
 import { ElectronTheme } from '../ui/models/electronTheme';
+import { UpdateInfo } from 'electron-updater';
+import { ProgressInfo } from 'electron-builder';
 
 export type Subscriptions = {
   'app:themeUpdated': (event: IpcRendererEvent, data: ElectronTheme) => void;
   'app:daemonHealthy': (event: IpcRendererEvent) => void;
   'app:daemonUnhealthy': (event: IpcRendererEvent) => void;
   'trigger:openSettings': (event: IpcRendererEvent) => void;
+
+  /**
+   * Updates
+   */
+  'app:checkingForUpdate': (event: IpcRendererEvent) => void;
+  'app:updateAvailable': (event: IpcRendererEvent, data: UpdateInfo) => void;
+  'app:updateNotAvailable': (event: IpcRendererEvent, data: UpdateInfo) => void;
+  'app:updateDownloadProgress': (event: IpcRendererEvent, data: ProgressInfo) => void;
+  'app:updateDownloaded': (event: IpcRendererEvent, data: UpdateInfo) => void;
+  'app:updateError': (event: IpcRendererEvent, data: Error) => void;
+  'app:updateCancelled': (event: IpcRendererEvent, data: UpdateInfo) => void;
 };

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -5,6 +5,7 @@ import { uiServiceBridge } from '../infra/ui/renderer';
 import { daemonAddressSupplier, daemonHealthySupplier, daemonWsAddressSupplier } from '../infra/daemon/renderer';
 import { configurationStore } from '../infra/store/store';
 import { configurationStoreBridge } from '../infra/store/renderer';
+import { appUpdaterBridge } from '../infra/autoupdate/renderer';
 
 contextBridge.exposeInMainWorld('utils', utilsBridge);
 contextBridge.exposeInMainWorld('subscriptions', subscriptionsBridge);
@@ -14,4 +15,6 @@ contextBridge.exposeInMainWorld('daemonAddress', daemonAddressSupplier());
 contextBridge.exposeInMainWorld('daemonWsAddress', daemonWsAddressSupplier());
 contextBridge.exposeInMainWorld('daemonHealthy', daemonHealthySupplier);
 contextBridge.exposeInMainWorld('NODE_ENV', process.env.NODE_ENV);
+contextBridge.exposeInMainWorld('appVersion', process.env.npm_package_version);
 contextBridge.exposeInMainWorld('configurationStore', configurationStoreBridge);
+contextBridge.exposeInMainWorld('appUpdater', appUpdaterBridge);

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -2,6 +2,7 @@ declare global {
   interface Window {
     isElectron: boolean;
     NODE_ENV: string;
+    appVersion: string;
   }
 }
 


### PR DESCRIPTION
Relates to #221 

* Conditions auto updating on the new `autoUpdateEnabled` store value
* Adds a scheduled job to check for updates every hour passively
* Cascades all of the auto updater's events to systemEvents, then subscriptions
* Adds a new `AppUpdaterBridge` that allows to check for updates, download updates and install them
* Adds new helper methods to the configuration store bridge - `getAutoUpdatingEnabled/setAutoUpdatingEnabled`
* Adds `appVersion` to window, shows the current app version