### PR TITLE
feat: add markdown loading support to renderer

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -112,6 +112,11 @@ const configuration: webpack.Configuration = {
           'file-loader',
         ],
       },
+      // Markdown
+      {
+        test: /\.md$/,
+        use: 'raw-loader',
+      },
     ],
   },
   plugins: [

--- a/.erb/configs/webpack.config.renderer.prod.ts
+++ b/.erb/configs/webpack.config.renderer.prod.ts
@@ -88,6 +88,11 @@ const configuration: webpack.Configuration = {
           'file-loader',
         ],
       },
+      // Markdown
+      {
+        test: /\.md$/,
+        use: 'raw-loader',
+      },
     ],
   },
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,1 @@
+declare module "*.md";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "allowJs": true,
-    "outDir": ".erb/dll"
+    "outDir": ".erb/dll",
+    "typeRoots": ["./node_modules/@types", "./src/types"],
   },
   "exclude": ["test", "release/build", "release/app/dist", ".erb/dll"]
 }


### PR DESCRIPTION
Example usage:

```typescript
import changelog from '../../CHANGELOG.md';
function Test() {
  return (
    <SomeMarkdownComponent>{changelog}</SomeMarkdownComponent>
  );
}
````